### PR TITLE
Listas con db room

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-MerqueloApp
+Merkelo

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/.kotlin/errors/errors-1758903401188.log
+++ b/.kotlin/errors/errors-1758903401188.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.20
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -9,15 +11,12 @@ android {
 
     defaultConfig {
         applicationId = "com.merqueloapp"
-        minSdk = 21
+        minSdk = 21        // si sigues con Room 2.6.1
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {
@@ -29,60 +28,55 @@ android {
             )
         }
     }
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
+    kotlinOptions { jvmTarget = "17" }
+
+    // 👇 si quieres, esto es válido y NO rompe:
+    // kotlin { jvmToolchain(17) }
+
+    buildFeatures { compose = true }
+
+    packaging { resources.excludes += "/META-INF/{AL2.0,LGPL2.1}" }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+        animationsDisabled = true
     }
 }
 
 dependencies {
-    // Compose
-    implementation(platform("androidx.compose:compose-bom:2025.01.00"))
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.activity:activity-compose:1.9.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
-
-    // Navigation Compose
-    implementation("androidx.navigation:navigation-compose:2.8.0")
-
-    // Accompanist System UI Controller (status bar)
-    implementation("com.google.accompanist:accompanist-systemuicontroller:0.36.0")
-
-    // Kotlin Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
-
-    implementation("androidx.compose.material:material-icons-extended:1.7.4") // íconos
-
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.material.icons.extended)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    debugImplementation(libs.androidx.ui.tooling)
+
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    implementation(libs.accompanist.systemuicontroller)
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Room (minSdk 21 con 2.6.1)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+
 }

--- a/app/src/main/java/com/merqueloapp/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/merqueloapp/data/local/AppDatabase.kt
@@ -1,0 +1,15 @@
+package com.merqueloapp.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [MarketListEntity::class, ListStoreEntity::class, ListItemEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun marketListDao(): MarketListDao
+    abstract fun listStoreDao(): ListStoreDao
+    abstract fun listItemDao(): ListItemDao
+}

--- a/app/src/main/java/com/merqueloapp/data/local/Dao.kt
+++ b/app/src/main/java/com/merqueloapp/data/local/Dao.kt
@@ -1,0 +1,31 @@
+package com.merqueloapp.data.local
+
+import androidx.room.*
+
+@Dao
+interface MarketListDao {
+    @Insert suspend fun insertList(list: MarketListEntity): Long
+    @Query("SELECT * FROM market_lists ORDER BY createdAt DESC")
+    suspend fun getLists(): List<MarketListEntity>
+
+    @Query("SELECT * FROM market_lists ORDER BY createdAt DESC")
+    fun observeLists(): kotlinx.coroutines.flow.Flow<List<MarketListEntity>>
+}
+
+@Dao
+interface ListStoreDao {
+    @Insert suspend fun insertStore(store: ListStoreEntity): Long
+    @Query("SELECT DISTINCT storeName FROM list_stores ORDER BY storeName ASC")
+    suspend fun getStoreSuggestions(): List<String>
+    @Query("SELECT * FROM list_stores WHERE listId = :listId")
+    suspend fun getStoresForList(listId: Long): List<ListStoreEntity>
+}
+
+@Dao
+interface ListItemDao {
+    @Insert suspend fun insertItem(item: ListItemEntity): Long
+    @Query("SELECT DISTINCT productName FROM list_items ORDER BY productName ASC")
+    suspend fun getProductSuggestions(): List<String>
+    @Query("SELECT * FROM list_items WHERE listId = :listId AND storeId = :storeId")
+    suspend fun getItemsForStore(listId: Long, storeId: Long): List<ListItemEntity>
+}

--- a/app/src/main/java/com/merqueloapp/data/local/DbProvider.kt
+++ b/app/src/main/java/com/merqueloapp/data/local/DbProvider.kt
@@ -1,0 +1,17 @@
+package com.merqueloapp.data.local
+
+import android.content.Context
+import androidx.room.Room
+
+object DbProvider {
+    @Volatile private var INSTANCE: AppDatabase? = null
+
+    fun get(context: Context): AppDatabase =
+        INSTANCE ?: synchronized(this) {
+            INSTANCE ?: Room.databaseBuilder(
+                context.applicationContext,
+                AppDatabase::class.java,
+                "merkelo.db"
+            ).build().also { INSTANCE = it }
+        }
+}

--- a/app/src/main/java/com/merqueloapp/data/local/Entities.kt
+++ b/app/src/main/java/com/merqueloapp/data/local/Entities.kt
@@ -1,0 +1,54 @@
+package com.merqueloapp.data.local
+
+import androidx.room.*
+
+@Entity(tableName = "market_lists")
+data class MarketListEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val createdAt: Long = System.currentTimeMillis()
+)
+
+@Entity(
+    tableName = "list_stores",
+    foreignKeys = [
+        ForeignKey(
+            entity = MarketListEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["listId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("listId")]
+)
+data class ListStoreEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val listId: Long,
+    val storeName: String
+)
+
+@Entity(
+    tableName = "list_items",
+    foreignKeys = [
+        ForeignKey(
+            entity = MarketListEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["listId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = ListStoreEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["storeId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("listId"), Index("storeId")]
+)
+data class ListItemEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val listId: Long,
+    val storeId: Long,
+    val productName: String,
+    val quantity: Int = 1
+)

--- a/app/src/main/java/com/merqueloapp/data/local/MarketRepository.kt
+++ b/app/src/main/java/com/merqueloapp/data/local/MarketRepository.kt
@@ -1,0 +1,43 @@
+package com.merqueloapp.data
+
+import android.content.Context
+import com.merqueloapp.data.local.*
+
+class MarketRepository(context: Context) {
+    private val db = DbProvider.get(context)
+    private val listDao = db.marketListDao()
+    private val storeDao = db.listStoreDao()
+    private val itemDao = db.listItemDao()
+
+    fun listsFlow() = listDao.observeLists()
+
+    suspend fun createListWithStoresAndItems(
+        listName: String,
+        storesWithProducts: Map<String, List<Pair<String, Int>>>
+    ): Long {
+        val listId = listDao.insertList(MarketListEntity(name = listName))
+        storesWithProducts.forEach { (storeRaw, products) ->
+            val storeName = storeRaw.toTitleCase()
+            val storeId = storeDao.insertStore(ListStoreEntity(listId = listId, storeName = storeName))
+            products.forEach { (prodRaw, qty) ->
+                val productName = prodRaw.toTitleCase()
+                itemDao.insertItem(
+                    ListItemEntity(
+                        listId = listId,
+                        storeId = storeId,
+                        productName = productName,
+                        quantity = qty.coerceAtLeast(1)
+                    )
+                )
+            }
+        }
+        return listId
+    }
+
+    suspend fun storeSuggestions(): List<String> = storeDao.getStoreSuggestions()
+    suspend fun productSuggestions(): List<String> = itemDao.getProductSuggestions()
+}
+
+private fun String.toTitleCase(): String =
+    lowercase().split(" ").filter { it.isNotBlank() }
+        .joinToString(" ") { it.replaceFirstChar { c -> c.titlecase() } }

--- a/app/src/main/java/com/merqueloapp/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/merqueloapp/navigation/AppNavigation.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.merqueloapp.ui.screens.CreateListScreen
 import com.merqueloapp.ui.screens.HomeScreen
 import com.merqueloapp.ui.screens.MarketScreen
 import com.merqueloapp.ui.screens.ProfileScreen
@@ -51,6 +52,14 @@ fun AppNavigation() {
             composable(Routes.MARKET) {
                 MarketScreen(
                     currentRoute = currentRoute,
+                    onSelectTab = { route -> navigateSingleTopTo(route, nav) },
+                    onCreateNew = { nav.navigate(Routes.CREATE_LIST) }   // 👈 navegar
+                )
+            }
+
+            composable(Routes.CREATE_LIST) {
+                CreateListScreen(                                     // 👈 pantalla destino mínima
+                    currentRoute = Routes.MARKET,                     // para que la bottom bar quede en “Market”
                     onSelectTab = { route -> navigateSingleTopTo(route, nav) }
                 )
             }

--- a/app/src/main/java/com/merqueloapp/navigation/Routes.kt
+++ b/app/src/main/java/com/merqueloapp/navigation/Routes.kt
@@ -6,6 +6,7 @@ object Routes {
     const val MARKET = "market"
     const val STORES = "stores"
     const val PROFILE = "profile"
+    const val CREATE_LIST = "create_list"
 }
 
 object SplashConfig {

--- a/app/src/main/java/com/merqueloapp/ui/screens/CreateListScreen.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/CreateListScreen.kt
@@ -1,29 +1,363 @@
 package com.merqueloapp.ui.screens
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.merqueloapp.navigation.Routes
 import com.merqueloapp.ui.components.AppBottomBar
 import com.merqueloapp.ui.components.AppTopBar
+import com.merqueloapp.ui.theme.MerkeloRed
+import kotlinx.coroutines.launch
 
 @Composable
 fun CreateListScreen(
     currentRoute: String,
-    onSelectTab: (String) -> Unit
+    onSelectTab: (String) -> Unit,
+    vm: CreateListViewModel = viewModel()
 ) {
+    LaunchedEffect(Unit) { vm.loadSuggestions() }
+
+    var showStores by remember { mutableStateOf(false) }
+    var showProductsForStore by remember { mutableStateOf<String?>(null) }
+
+    // Estados del VM
+    val name by vm.listName.collectAsState()
+    val stores by vm.stores.collectAsState()
+    val storeSuggestions by vm.storeSuggestions.collectAsState()
+    val productSuggestions by vm.productSuggestions.collectAsState()
+
+    // Validaciones
+    val hasAtLeastOneProduct = stores.any { it.products.isNotEmpty() }
+    val canSave = name.isNotBlank() && stores.isNotEmpty() && hasAtLeastOneProduct
+
+    val snackbarHost = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
     Scaffold(
         topBar = { AppTopBar(title = "Lista") },
-        bottomBar = { AppBottomBar(currentRoute = currentRoute, onSelect = onSelectTab) }
+        bottomBar = { AppBottomBar(currentRoute = currentRoute, onSelect = onSelectTab) },
+        snackbarHost = { SnackbarHost(snackbarHost) }
     ) { inner ->
-        Box(
-            modifier = Modifier.fillMaxSize().padding(inner),
-            contentAlignment = Alignment.Center
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .padding(horizontal = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Aquí construiremos el formulario (nombre, tienda/s, productos…)
+            Spacer(Modifier.height(12.dp))
+            Text("Crea una nueva lista de mercado", style = MaterialTheme.typography.titleLarge)
+
+            Spacer(Modifier.height(20.dp))
+
+            // Nombre de la lista
+            OutlinedTextField(
+                value = name,
+                onValueChange = vm::setListName,
+                label = { Text("Escribe el nombre de tu lista") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            if (name.isBlank()) {
+                Text("Debes escribir un nombre.", color = MaterialTheme.colorScheme.error)
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Tienda (selección única)
+            ElevatedButton(
+                onClick = { showStores = true },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                colors = ButtonDefaults.elevatedButtonColors(
+                    containerColor = MerkeloRed,
+                    contentColor = Color.White
+                )
+            ) {
+                Text("Selecciona o escribe tu tienda", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+            }
+            if (stores.isEmpty()) {
+                Text("Agrega una tienda.", color = MaterialTheme.colorScheme.error)
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Productos (por la tienda seleccionada)
+            if (stores.isNotEmpty()) {
+                ElevatedButton(
+                    onClick = { showProductsForStore = stores.first().name },
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                    colors = ButtonDefaults.elevatedButtonColors(
+                        containerColor = MerkeloRed,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text("Selecciona o escribe tus Productos", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+                }
+                if (!hasAtLeastOneProduct) {
+                    Text("Agrega al menos un producto.", color = MaterialTheme.colorScheme.error)
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Resumen SIEMPRE visible
+            Text(
+                fontWeight = FontWeight.Medium,
+                fontSize = 18.sp,
+                text = "Resumen", style = MaterialTheme.typography.titleMedium)
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                if (stores.isEmpty()) {
+                    item { Text("Sin tiendas ni productos aún.", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                } else {
+                    items(stores) { st ->
+                        Text(
+                            text = "Tienda: ${st.name}",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 18.sp,
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+                        st.products.forEach { p ->
+                            Text(
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 18.sp,
+                                text = "• ${p.name} x${p.quantity}", style = MaterialTheme.typography.bodyMedium)
+                        }
+                        Spacer(Modifier.height(12.dp))
+                    }
+                }
+            }
+
+            // Finalizar / Guardar definitiva
+            Button(
+                onClick = {
+                    if (!canSave) {
+                        scope.launch {
+                            snackbarHost.showSnackbar("Completa nombre, tienda y al menos un producto.")
+                        }
+                    } else {
+                        vm.save {
+                            onSelectTab(Routes.HOME)
+                        }
+                    }
+                },
+                enabled = canSave,
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                colors = ButtonDefaults.elevatedButtonColors(
+                    containerColor = MerkeloRed,
+                    contentColor = Color.White
+                )
+            ) {
+                Text("Finalizar", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+            }
+            Spacer(Modifier.height(12.dp))
         }
     }
+
+    // D I Á L O G O S
+
+    // Tiendas (selección única con commit en Guardar)
+    if (showStores) {
+        StorePickerDialog(
+            currentStore = stores.firstOrNull()?.name,
+            suggestions = storeSuggestions,
+            onDismiss = { showStores = false },
+            onCommitStore = { selectedOrTyped ->
+                vm.setSingleStore(selectedOrTyped)
+                showStores = false
+                // opcional: abrir de una vez productos
+                // showProductsForStore = selectedOrTyped
+            }
+        )
+    }
+
+    // Productos: commit en Guardar
+    showProductsForStore?.let { storeName ->
+        val selectedProducts = stores.find { it.name == storeName }?.products ?: emptyList()
+        ProductPickerDialog(
+            storeName = storeName,
+            initial = selectedProducts,
+            suggestions = productSuggestions,
+            onDismiss = { showProductsForStore = null },
+            onCommit = { finalProducts ->
+                vm.setProductsForStore(storeName, finalProducts)
+                showProductsForStore = null
+            }
+        )
+    }
+}
+
+/* --------------------  Diálogo: Seleccionar UNA tienda  -------------------- */
+@Composable
+private fun StorePickerDialog(
+    currentStore: String?,
+    suggestions: List<String>,
+    onDismiss: () -> Unit,
+    onCommitStore: (String) -> Unit
+) {
+    var input by remember { mutableStateOf(TextFieldValue("")) }
+    var selected by remember { mutableStateOf(currentStore) } // estado local para feedback inmediato
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                val typed = input.text.trim()
+                val final = if (typed.isNotEmpty()) typed else selected
+                if (!final.isNullOrBlank()) onCommitStore(final)
+                else onDismiss()
+            }) {
+                Text("Guardar", fontWeight = FontWeight.Medium, fontSize = 18.sp, color = MerkeloRed)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cerrar", fontWeight = FontWeight.Medium, fontSize = 18.sp, color = MerkeloRed)
+            }
+        },
+        title = { Text("Selecciona o escribe tu tienda") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    placeholder = { Text("Ej: La Vaquita") },
+                    singleLine = true,
+                    trailingIcon = {
+                        if (input.text.isNotEmpty()) TextButton({ input = TextFieldValue("") }) { Text("X") }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(12.dp))
+                Text("Sugerencias", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+                Spacer(Modifier.height(8.dp))
+                suggestions.forEach { s ->
+                    val checked = selected?.equals(s, ignoreCase = true) == true
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = { isChecked ->
+                                selected = if (isChecked) s else null
+                            },
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = MerkeloRed,
+                                checkmarkColor = Color.White
+                            )
+                        )
+                        Text(s)
+                    }
+                }
+            }
+        }
+    )
+}
+
+/* --------------------  Diálogo: Productos (lista local + commit)  -------------------- */
+@Composable
+private fun ProductPickerDialog(
+    storeName: String,
+    initial: List<ProductSelection>,
+    suggestions: List<String>,
+    onDismiss: () -> Unit,
+    onCommit: (List<ProductSelection>) -> Unit
+) {
+    var input by remember { mutableStateOf(TextFieldValue("")) }
+    var qty by remember { mutableStateOf("1") }
+
+    // lista local editable para feedback inmediato
+    val local = remember(initial) { initial.map { it.copy() }.toMutableStateList() }
+
+    fun toggleSuggestion(name: String) {
+        val idx = local.indexOfFirst { it.name.equals(name, true) }
+        if (idx >= 0) local.removeAt(idx)
+        else local.add(ProductSelection(name, 1))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onCommit(local.toList()) }) {
+                Text("Guardar", fontWeight = FontWeight.Medium, fontSize = 18.sp, color = MerkeloRed)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cerrar", fontWeight = FontWeight.Medium, fontSize = 18.sp, color = MerkeloRed)
+            }
+        },
+        title = { Text("Productos de $storeName") },
+        text = {
+            Column {
+                // Escribir producto y cantidad + botón Añadir
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    placeholder = { Text("Escribe un producto") },
+                    singleLine = true,
+                    trailingIcon = {
+                        if (input.text.isNotEmpty()) TextButton({ input = TextFieldValue("") }) { Text("X") }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = qty,
+                    onValueChange = { qty = it.filter { ch -> ch.isDigit() }.ifEmpty { "1" } },
+                    label = { Text("Cantidad", fontWeight = FontWeight.Medium, fontSize = 18.sp) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        val p = input.text.trim()
+                        val q = qty.toIntOrNull() ?: 1
+                        if (p.isNotEmpty()) {
+                            val idx = local.indexOfFirst { it.name.equals(p, true) }
+                            if (idx >= 0) local[idx] = local[idx].copy(quantity = q.coerceAtLeast(1))
+                            else local.add(ProductSelection(p, q.coerceAtLeast(1)))
+                            input = TextFieldValue("")
+                        }
+                    },
+                    modifier = Modifier.align(Alignment.End)
+                ) { Text("Añadir") }
+
+                Spacer(Modifier.height(12.dp))
+                Text("Sugerencias", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+                suggestions.forEach { s ->
+                    val checked = local.any { it.name.equals(s, true) }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = { toggleSuggestion(s) },
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = MerkeloRed,
+                                checkmarkColor = Color.White
+                            )
+                        )
+                        Text(s)
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Text("Seleccionados", fontWeight = FontWeight.Medium, fontSize = 18.sp, color = MerkeloRed)
+                local.forEach {
+                    Text("• ${it.name} x${it.quantity}", fontWeight = FontWeight.Medium, fontSize = 18.sp)
+                }
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/merqueloapp/ui/screens/CreateListScreen.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/CreateListScreen.kt
@@ -1,0 +1,29 @@
+package com.merqueloapp.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.merqueloapp.ui.components.AppBottomBar
+import com.merqueloapp.ui.components.AppTopBar
+
+@Composable
+fun CreateListScreen(
+    currentRoute: String,
+    onSelectTab: (String) -> Unit
+) {
+    Scaffold(
+        topBar = { AppTopBar(title = "Lista") },
+        bottomBar = { AppBottomBar(currentRoute = currentRoute, onSelect = onSelectTab) }
+    ) { inner ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(inner),
+            contentAlignment = Alignment.Center
+        ) {
+            // Aquí construiremos el formulario (nombre, tienda/s, productos…)
+        }
+    }
+}

--- a/app/src/main/java/com/merqueloapp/ui/screens/CreateListViewModel.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/CreateListViewModel.kt
@@ -1,0 +1,134 @@
+package com.merqueloapp.ui.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.merqueloapp.data.MarketRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+// Sugerencias "quemadas" para tiendas
+private val defaultStores = listOf("D1", "Euro", "La Vaquita", "Éxito", "Carulla", "Ara", "Isimo", "Surtimax", "Jumbo", "PriceSmart", "Makro")
+
+data class StoreSelection(
+    val name: String,
+    val products: MutableList<ProductSelection> = mutableListOf()
+)
+
+data class ProductSelection(
+    val name: String,
+    var quantity: Int = 1
+)
+
+class CreateListViewModel(app: Application) : AndroidViewModel(app) {
+
+    private val repo = MarketRepository(app)
+
+    private val _listName = MutableStateFlow("")
+    val listName: StateFlow<String> = _listName
+
+    // Lista actual en edición: por ahora 1 sola tienda
+    private val _stores = MutableStateFlow(mutableListOf<StoreSelection>())
+    val stores: StateFlow<List<StoreSelection>> = _stores
+
+    private val _storeSuggestions = MutableStateFlow<List<String>>(emptyList())
+    val storeSuggestions: StateFlow<List<String>> = _storeSuggestions
+
+    private val _productSuggestions = MutableStateFlow<List<String>>(emptyList())
+    val productSuggestions: StateFlow<List<String>> = _productSuggestions
+
+    /* -------------------  Estado básico  ------------------- */
+
+    fun setListName(s: String) { _listName.value = s }
+
+    /** Selecciona UNA sola tienda (reemplaza la actual). */
+    fun setSingleStore(name: String) {
+        val s = name.toTitleCase()
+        _stores.value = mutableListOf(StoreSelection(s))
+        // Forzar notificación
+        _stores.value = _stores.value.toMutableList()
+    }
+
+    /** Limpia la tienda seleccionada. */
+    fun clearStore() {
+        _stores.value.clear()
+        _stores.value = _stores.value.toMutableList()
+    }
+
+    /* -------------------  Productos  ------------------- */
+
+    /** Agrega o actualiza un producto para la tienda dada. */
+    fun addProduct(storeName: String, prod: String, qty: Int) {
+        val s = storeName.toTitleCase()
+        val p = prod.toTitleCase()
+        val list = _stores.value.toMutableList()
+        val store = list.find { it.name.equals(s, true) } ?: return
+        val existing = store.products.find { it.name.equals(p, true) }
+        if (existing == null) {
+            store.products.add(ProductSelection(p, qty.coerceAtLeast(1)))
+        } else {
+            existing.quantity = qty.coerceAtLeast(1)
+        }
+        _stores.value = list
+    }
+
+    /** Quita un producto de la tienda dada. */
+    fun removeProduct(storeName: String, prod: String) {
+        val list = _stores.value.toMutableList()
+        list.find { it.name.equals(storeName, true) }?.let { st ->
+            st.products.removeAll { it.name.equals(prod, true) }
+            _stores.value = list
+        }
+    }
+
+    /** Reemplaza COMPLETAMENTE los productos de la tienda (commit desde el diálogo). */
+    fun setProductsForStore(storeName: String, products: List<ProductSelection>) {
+        val s = storeName.toTitleCase()
+        val normalized = products.map {
+            ProductSelection(it.name.toTitleCase(), it.quantity.coerceAtLeast(1))
+        }
+        val list = _stores.value.toMutableList()
+        val idx = list.indexOfFirst { it.name.equals(s, true) }
+        if (idx >= 0) {
+            list[idx] = list[idx].copy(products = normalized.toMutableList())
+        } else {
+            list.add(StoreSelection(name = s, products = normalized.toMutableList()))
+        }
+        _stores.value = list
+    }
+
+    /* -------------------  Sugerencias  ------------------- */
+
+    fun loadSuggestions() {
+        viewModelScope.launch {
+            val fromDbStores = repo.storeSuggestions()
+            _storeSuggestions.value = (defaultStores + fromDbStores)
+                .distinctBy { it.lowercase() }
+                .sorted()
+
+            // Por ahora solo desde BD; si quieres defaults de productos,
+            // aquí puedes hacer un merge similar.
+            _productSuggestions.value = repo.productSuggestions()
+        }
+    }
+
+    /* -------------------  Guardado  ------------------- */
+
+    fun save(onSaved: (Long) -> Unit) {
+        viewModelScope.launch {
+            val map = _stores.value.associate { st ->
+                st.name to st.products.map { it.name to it.quantity }
+            }
+            val id = repo.createListWithStoresAndItems(_listName.value.toTitleCase(), map)
+            onSaved(id)
+        }
+    }
+}
+
+/* -------------------  Utils  ------------------- */
+
+private fun String.toTitleCase(): String =
+    lowercase().split(" ")
+        .filter { it.isNotBlank() }
+        .joinToString(" ") { it.replaceFirstChar { c -> c.titlecase() } }

--- a/app/src/main/java/com/merqueloapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.merqueloapp.navigation.Routes
 import com.merqueloapp.ui.components.AppBottomBar
 import com.merqueloapp.ui.components.AppTopBar
@@ -19,12 +20,11 @@ import com.merqueloapp.ui.components.AppTopBar
 fun HomeScreen(
     currentRoute: String,
     onCreateNew: () -> Unit,
-    onOpenList: (String) -> Unit,
-    onSelectTab: (String) -> Unit
+    onOpenList: (String) -> Unit,  // por ahora pasamos el nombre; luego usaremos id
+    onSelectTab: (String) -> Unit,
+    vm: HomeViewModel = viewModel()
 ) {
-    val lists = remember {
-        mutableStateListOf("Lista Mercado 1", "Lista Mercado 2", "Lista Desayuno")
-    }
+    val lists by vm.lists.collectAsState()
 
     Scaffold(
         topBar = { AppTopBar(title = "Inicio") },
@@ -55,9 +55,9 @@ fun HomeScreen(
                     fontSize = 28.sp
                 )
             }
-            items(lists) { title ->
+            items(lists) { list ->
                 ElevatedCard(
-                    onClick = { onOpenList(title) },
+                    onClick = { onOpenList(list.name) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 10.dp)
@@ -69,14 +69,19 @@ fun HomeScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = title,
+                            text = list.name,
                             style = MaterialTheme.typography.titleLarge,
                             fontSize = 22.sp
                         )
                     }
                 }
             }
+            if (lists.isEmpty()) {
+                item { Spacer(Modifier.height(20.dp)) }
+                item { Text("Aún no tienes listas. ¡Crea la primera!", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            }
             item { Spacer(Modifier.height(80.dp)) }
         }
     }
 }
+

--- a/app/src/main/java/com/merqueloapp/ui/screens/HomeViewModel.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/HomeViewModel.kt
@@ -1,0 +1,18 @@
+package com.merqueloapp.ui.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.merqueloapp.data.MarketRepository
+import com.merqueloapp.data.local.MarketListEntity
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class HomeViewModel(app: Application) : AndroidViewModel(app) {
+    private val repo = MarketRepository(app)
+
+    val lists: StateFlow<List<MarketListEntity>> =
+        repo.listsFlow()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+}

--- a/app/src/main/java/com/merqueloapp/ui/screens/MarketScreen.kt
+++ b/app/src/main/java/com/merqueloapp/ui/screens/MarketScreen.kt
@@ -24,6 +24,7 @@ import com.merqueloapp.ui.theme.MerkeloRed
 fun MarketScreen(
     currentRoute: String,
     onSelectTab: (String) -> Unit,
+    onCreateNew: () -> Unit,
 ) {
     Scaffold(
         topBar = { AppTopBar(title = "Mercado") },
@@ -60,7 +61,7 @@ fun MarketScreen(
             // Botón "Crear nuevo"
             RoundedBigButton(
                 text = "Crear nuevo",
-                onClick = { /* TODO: navegar a pantalla de crear lista */ },
+                onClick = onCreateNew,
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
                 backgroundColor = MerkeloRed
             )

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-    <!-- Tema NORMAL de la app -->
 <resources>
     <style name="Theme.MerqueloApp" parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>
-
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,31 +1,46 @@
 [versions]
 agp = "8.6.0"
-kotlin = "1.9.0"
-coreKtx = "1.13.1"
-junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.6"
+kotlin = "2.0.20"               # <— subimos Kotlin para alinear todo
+composeBom = "2025.01.00"       # puedes dejar esta, estable
 activityCompose = "1.9.2"
-composeBom = "2024.04.01"
+lifecycleRuntimeKtx = "2.8.6"
+navigationCompose = "2.8.0"
+accompanistSystemUi = "0.36.0"
+coreKtx = "1.13.1"
+coroutines = "1.9.0"
+room = "2.6.1"                  # <— permite minSdk 21
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+
+# Room (artefactos correctos)
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+# Otros
+accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanistSystemUi" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+
+# Test (si los usas)
+junit = { group = "junit", name = "junit", version = "4.13.2" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version = "1.2.1" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version = "3.6.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version = "2.0.20-1.0.24" }  # para Room
+kotlin-compose      = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }  # 👈 NUEVO
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
+        google()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -18,6 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-
-rootProject.name = "MerqueloApp"
+rootProject.name = "Merkelo"
 include(":app")


### PR DESCRIPTION
Hasta ahora hemos construido la base de  Merkelo en Android con Kotlin + Jetpack Compose, comenzando por la configuración del entorno, splash animado y sistema de navegación con pantallas principales (Home, Market, Stores, Profile). Implementamos la pantalla de crear listas de mercado, donde el usuario puede asignar un nombre, seleccionar una tienda (solo una, de sugerencias o escrita manualmente) y agregar productos con cantidades, todo mostrando un resumen en tiempo real. Además, conectamos esta lógica a un ViewModel con Room y repositorio, para que las listas se guarden y puedan mostrarse luego en el Home. También hemos configurado correctamente Gradle, Compose Compiler y dependencias, resolviendo errores de compatibilidad. una app con navegación, manejo de estado, validaciones y persistencia de datos.